### PR TITLE
Stop using deprecated Buffer constructor

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,7 +35,7 @@ setInterval(function(){
 }, 150);
 
 setInterval(function(){
-  c.send(new Buffer('hello'));
+  c.send(Buffer.from('hello'));
 }, 150);
 ```
 

--- a/benchmarks/pub.js
+++ b/benchmarks/pub.js
@@ -3,7 +3,7 @@ var punt = require('..');
 
 var c = punt.connect('0.0.0.0:5050');
 
-var b = new Buffer(Array(256).join('a'));
+var b = Buffer.from(Array(256).join('a'));
 function next() {
   var n = 100;
   while (n--) c.send(b);

--- a/examples/single.js
+++ b/examples/single.js
@@ -18,11 +18,11 @@ setInterval(function(){
 }, 150);
 
 setInterval(function(){
-  c.send(new Buffer('hello world'));
+  c.send(Buffer.from('hello world'));
 }, 150);
 
 setInterval(function(){
-  c.send(new Buffer('hello world with fn'), function(err, bytes) {
+  c.send(Buffer.from('hello world with fn'), function(err, bytes) {
     console.log('Sent %s bytes', bytes);
   });
 }, 150);

--- a/test/index.js
+++ b/test/index.js
@@ -27,7 +27,7 @@ describe('.send(buffer)', function(){
       done();
     });
 
-    c.send(new Buffer('Hello'));
+    c.send(Buffer.from('Hello'));
   })
 
   it('should gracefully fail message parsing', function(done){
@@ -44,13 +44,13 @@ describe('.send(buffer)', function(){
       done();
     });
 
-    s.onmessage(new Buffer('fail'));
+    s.onmessage(Buffer.from('fail'));
   })
 })
 
 describe('.send(buffer, callback)', function(){
   it('should invoke the callback', function(done){
-    c.send(new Buffer('Hello'), new Buffer('World'), function(err, bytes) {
+    c.send(Buffer.from('Hello'), Buffer.from('World'), function(err, bytes) {
       assert(!err);
       done();
     });


### PR DESCRIPTION
The `new Buffer(string|number)` form was deemed an attack vector
and deprecated. All Node.js v6.x+ versions have the `.from()`,
`.alloc()` and `.allocUnsafe()` family of Buffer methods now.